### PR TITLE
Mark Forecast as EOL

### DIFF
--- a/dev.salaniLeo.forecast.json
+++ b/dev.salaniLeo.forecast.json
@@ -20,7 +20,7 @@
         "*.a"
     ],
     "modules": [
-  	"data/dependencies/python3-requests.json",
+        "data/dependencies/python3-requests.json",
         {
             "name": "forecast",
             "buildsystem": "meson",
@@ -31,9 +31,6 @@
                     "tag" : "1.1.1",
                     "commit" : "7552add8dbb622f15c8d8f7e3f5d3c51a983f06d"
                 }
-            ],
-            "dependencies": [
-                "python3-requests"
             ]
         }
     ]

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
The project archived by the developer.

See: https://github.com/SalaniLeo/Forecast

> This repository was archived by the owner on Sep 24, 2025.
> It is now read-only.